### PR TITLE
Refactor CLI and make database drivers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ An ETL package for loading data from the ClinicalTrials.gov V2 API into a relati
     ```
 
 2.  **Create a virtual environment and install dependencies:**
+    The package uses optional dependencies for different database backends.
+    To install with PostgreSQL support, run:
     ```bash
     uv venv
     source .venv/bin/activate
-    uv pip install -e .
+    uv pip install -e .[postgres]
     ```
 
 ## Configuration
@@ -49,12 +51,12 @@ You can also place these variables in a `.env` file in the project root.
 
 The package provides a command-line interface for operation.
 
-### Initialize the Database
+### Manage the Database Schema
 
-Before running the ETL for the first time, you need to initialize the database schema:
+Before running the ETL for the first time, you need to initialize the database schema by running migrations:
 
 ```bash
-py-load-clinicaltrialsgov init-db --connector postgres
+py-load-clinicaltrialsgov migrate-db
 ```
 
 ### Run the ETL
@@ -74,7 +76,7 @@ py-load-clinicaltrialsgov run --load-type full --connector postgres
 To check the status of the last ETL run, use the `status` command:
 
 ```bash
-py-load-clinicaltrialsgov run status --connector postgres
+py-load-clinicaltrialsgov status --connector postgres
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "typer[all]",
     "tenacity",
     "pandas",
-    "psycopg[binary]",
     "pyarrow",
     "pydantic-settings",
     "structlog",
@@ -22,6 +21,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+postgres = ["psycopg[binary]"]
 dev = [
     "ruff",
     "mypy",

--- a/src/py_load_clinicaltrialsgov/cli.py
+++ b/src/py_load_clinicaltrialsgov/cli.py
@@ -119,20 +119,6 @@ def run(
 from alembic.config import Config
 from alembic import command
 
-@app.command()
-def init_db(
-    connector_name: Annotated[str, typer.Option(help="Name of the database connector to use.")] = "postgres",
-):
-    """
-    Initialize the database by creating all tables and stamping it with the latest migration.
-    This is useful for setting up a new database from scratch.
-    """
-    logger.info("initializing_database_schema", connector_name=connector_name)
-
-    # Run the initial schema setup
-    migrate_db()
-
-    logger.info("database_schema_initialized")
 
 
 @app.command()
@@ -146,6 +132,8 @@ def migrate_db(
     logger.info("database_migrations_completed")
 
 
+import json
+
 @app.command()
 def status(
     connector_name: Annotated[str, typer.Option(help="Name of the database connector to use.")] = "postgres",
@@ -153,17 +141,24 @@ def status(
     """
     Check the status of the last ETL run.
     """
-    connector = get_connector(connector_name)
-    with connector.conn.cursor() as cur:
-        cur.execute("SELECT load_timestamp, status, metrics FROM load_history ORDER BY load_timestamp DESC LIMIT 1")
-        result = cur.fetchone()
-        if result:
-            timestamp, status_val, metrics = result
-            print(f"Last run at: {timestamp}")
-            print(f"Status: {status_val}")
-            print(f"Metrics: {metrics}")
+    logger.info("checking_etl_status")
+    try:
+        connector = get_connector(connector_name)
+        history = connector.get_last_load_history()
+
+        if history:
+            typer.echo("Last ETL Run Status:")
+            typer.echo(f"  Timestamp: {history['load_timestamp'].isoformat()}")
+            typer.echo(f"  Status: {history['status']}")
+            typer.echo("  Metrics:")
+            # Pretty print the JSON metrics
+            typer.echo(json.dumps(history['metrics'], indent=4))
         else:
-            print("No load history found.")
+            typer.echo("No ETL run history found.")
+    except Exception as e:
+        logger.error("failed_to_get_status", error=str(e), exc_info=True)
+        typer.echo(f"Error: Could not retrieve status. {e}", err=True)
+        raise typer.Exit(code=1)
 
 if __name__ == "__main__":
     app()

--- a/src/py_load_clinicaltrialsgov/connectors/interface.py
+++ b/src/py_load_clinicaltrialsgov/connectors/interface.py
@@ -51,6 +51,15 @@ class DatabaseConnectorInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_last_load_history(self) -> Dict[str, Any] | None:
+        """
+        Retrieve the most recent entry from the load history.
+        Returns:
+            A dictionary representing the last load history record, or None.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def record_load_history(self, status: str, metrics: Dict[str, Any]) -> None:
         """
         Log the outcome of the ETL run in a history table.

--- a/src/py_load_clinicaltrialsgov/connectors/postgres.py
+++ b/src/py_load_clinicaltrialsgov/connectors/postgres.py
@@ -1,7 +1,16 @@
 import pandas as pd
 from typing import Dict, List, Any, Literal
 from datetime import datetime, UTC
-import psycopg
+
+try:
+    import psycopg
+except ImportError:
+    raise ImportError(
+        "PostgreSQL dependencies are not installed. "
+        "Please install the package with the 'postgres' extra: "
+        "pip install py-load-clinicaltrialsgov[postgres]"
+    )
+
 
 from py_load_clinicaltrialsgov.connectors.interface import DatabaseConnectorInterface
 from py_load_clinicaltrialsgov.config import settings
@@ -125,6 +134,15 @@ class PostgresConnector(DatabaseConnectorInterface):
             cur.execute("SELECT MAX(load_timestamp) FROM load_history WHERE status = 'SUCCESS'")
             result = cur.fetchone()
             return result[0] if result else None
+
+    def get_last_load_history(self) -> Dict[str, Any] | None:
+        """
+        Gets the most recent load history record.
+        """
+        with self.conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT * FROM load_history ORDER BY load_timestamp DESC LIMIT 1")
+            result = cur.fetchone()
+            return result
 
     def record_load_history(self, status: str, metrics: Dict[str, Any]) -> None:
         """

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,3 +72,78 @@ def test_run_command_sends_failed_study_to_dlq(
         mock_connector.manage_transaction.assert_any_call("begin")
         mock_connector.manage_transaction.assert_any_call("commit")
         mock_connector.record_load_history.assert_any_call("SUCCESS", {"records_processed": 0})
+
+
+def test_status_command_success(mock_connector):
+    """
+    Verify the status command prints the latest load history successfully.
+    """
+    # Arrange
+    from datetime import datetime
+    import json
+    history_record = {
+        "load_timestamp": datetime(2023, 1, 1, 12, 0, 0),
+        "status": "SUCCESS",
+        "metrics": {"records_processed": 100}
+    }
+    mock_connector.get_last_load_history.return_value = history_record
+
+    with patch("py_load_clinicaltrialsgov.cli.get_connector", return_value=mock_connector):
+        # Act
+        result = runner.invoke(app, ["status"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "Last ETL Run Status:" in result.stdout
+        assert f"Timestamp: {history_record['load_timestamp'].isoformat()}" in result.stdout
+        assert f"Status: {history_record['status']}" in result.stdout
+        assert json.dumps(history_record['metrics'], indent=4) in result.stdout
+
+
+def test_status_command_no_history(mock_connector):
+    """
+    Verify the status command handles the case where no history is found.
+    """
+    # Arrange
+    mock_connector.get_last_load_history.return_value = None
+
+    with patch("py_load_clinicaltrialsgov.cli.get_connector", return_value=mock_connector):
+        # Act
+        result = runner.invoke(app, ["status"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "No ETL run history found." in result.stdout
+
+
+def test_status_command_failure(mock_connector):
+    """
+    Verify the status command handles exceptions gracefully.
+    """
+    # Arrange
+    error_message = "Database connection failed"
+    mock_connector.get_last_load_history.side_effect = Exception(error_message)
+
+    with patch("py_load_clinicaltrialsgov.cli.get_connector", return_value=mock_connector):
+        # Act
+        result = runner.invoke(app, ["status"], catch_exceptions=False)
+
+        # Assert
+        assert result.exit_code == 1
+        # The error message is now in the exception info
+        assert isinstance(result.exception, SystemExit)
+
+
+@patch("py_load_clinicaltrialsgov.cli.command")
+def test_migrate_db_command(mock_alembic_command):
+    """
+    Verify the migrate-db command calls alembic correctly.
+    """
+    # Act
+    result = runner.invoke(app, ["migrate-db"])
+
+    # Assert
+    assert result.exit_code == 0
+    mock_alembic_command.upgrade.assert_called_once()
+    # Check that the second argument is 'head'
+    assert mock_alembic_command.upgrade.call_args[0][1] == "head"


### PR DESCRIPTION
This commit introduces several improvements to the `py-load-clinicaltrialsgov` package based on a gap analysis against the FRD.

Key changes:
- **CLI Improvements:**
  - The `status` command has been implemented to provide a detailed, user-friendly report of the last ETL run by fetching data from the `load_history` table.
  - The redundant `init-db` command has been removed in favor of `migrate-db`, simplifying the schema management workflow.
  - Unit tests for the new CLI commands have been added.

- **Optional Dependencies:**
  - The `psycopg` dependency for PostgreSQL has been moved to an optional dependency group (`[postgres]`).
  - The `PostgresConnector` now provides a clear `ImportError` if the user attempts to use it without installing the optional dependencies, improving user experience.
  - The `README.md` has been updated to reflect these new installation instructions.

These changes bring the package into closer alignment with the FRD, improving usability, extensibility, and robustness.