### PR TITLE
This commit refactors the ETL architecture to better align with the S…

### DIFF
--- a/src/py_load_clinicaltrialsgov/cli.py
+++ b/src/py_load_clinicaltrialsgov/cli.py
@@ -89,6 +89,16 @@ def run(
 
         log.info("finished_processing_studies", total_record_count=record_count)
 
+        # This metadata now lives in the orchestrator, not the connector.
+        table_metadata = {
+            "raw_studies": ["nct_id"],
+            "studies": ["nct_id"],
+            "sponsors": ["nct_id", "name", "agency_class"],
+            "conditions": ["nct_id", "name"],
+            "interventions": ["nct_id", "intervention_type", "name"],
+            "design_outcomes": ["nct_id", "outcome_type", "measure"],
+        }
+
         dataframes = transformer.get_dataframes()
         for table_name, df in dataframes.items():
             if not df.empty:
@@ -97,9 +107,14 @@ def run(
                     table_name=table_name,
                     record_count=len(df),
                 )
+                primary_keys = table_metadata.get(table_name)
+                if not primary_keys:
+                    log.error("no_primary_key_defined_for_table", table_name=table_name)
+                    # Optionally, raise an error or skip the table
+                    continue
+
                 connector.bulk_load_staging(table_name, df)
-                # The connector now handles its own primary key logic
-                connector.execute_merge(table_name)
+                connector.execute_merge(table_name, primary_keys)
 
         metrics = {"records_processed": record_count}
         connector.record_load_history("SUCCESS", metrics)

--- a/src/py_load_clinicaltrialsgov/connectors/interface.py
+++ b/src/py_load_clinicaltrialsgov/connectors/interface.py
@@ -30,12 +30,14 @@ class DatabaseConnectorInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def execute_merge(self, table_name: str) -> None:
+    def execute_merge(self, table_name: str, primary_keys: List[str]) -> None:
         """
         Perform an UPSERT/MERGE from a staging table to the final table.
 
         Args:
             table_name: The name of the final target table.
+            primary_keys: A list of column names that form the natural
+                          primary key for the merge operation.
         """
         raise NotImplementedError
 

--- a/src/py_load_clinicaltrialsgov/connectors/postgres.py
+++ b/src/py_load_clinicaltrialsgov/connectors/postgres.py
@@ -22,16 +22,6 @@ class PostgresConnector(DatabaseConnectorInterface):
 
     def __init__(self):
         self.conn = psycopg.connect(settings.db.dsn)
-        # Define table metadata, including natural keys for merge logic
-        self.table_metadata = {
-            "raw_studies": {"pk": ["nct_id"]},
-            "studies": {"pk": ["nct_id"]},
-            # For child tables, the PK is the natural key, not the surrogate `id`
-            "sponsors": {"pk": ["nct_id", "name", "agency_class"]},
-            "conditions": {"pk": ["nct_id", "name"]},
-            "interventions": {"pk": ["nct_id", "intervention_type", "name"]},
-            "design_outcomes": {"pk": ["nct_id", "outcome_type", "measure"]},
-        }
 
     def initialize_schema(self) -> None:
         """
@@ -60,18 +50,13 @@ class PostgresConnector(DatabaseConnectorInterface):
             with cur.copy(f"COPY {staging_table_name} FROM STDIN WITH (FORMAT CSV)") as copy:
                 copy.write(csv_buffer.read())
 
-    def execute_merge(self, table_name: str) -> None:
+    def execute_merge(self, table_name: str, primary_keys: List[str]) -> None:
         """
-        Merges data from a staging table to a final table using a generic
-        and efficient INSERT ON CONFLICT (UPSERT) strategy.
-        This implementation is now generic for all tables.
+        Merges data from a staging table to a final table using an efficient
+        INSERT ON CONFLICT (UPSERT) for parent tables and a DELETE/INSERT
+        pattern for child tables.
         """
-        if table_name not in self.table_metadata:
-            return
-
         staging_table_name = f"staging_{table_name}"
-        # The conflict target is the natural primary key of the table.
-        conflict_keys = self.table_metadata[table_name]["pk"]
 
         with self.conn.cursor() as cur:
             # Get column names from the final table, excluding the serial `id`
@@ -86,39 +71,38 @@ class PostgresConnector(DatabaseConnectorInterface):
                 return
 
             col_names = ", ".join(f'"{c}"' for c in columns)
-            conflict_target = ", ".join(f'"{pk}"' for pk in conflict_keys)
 
-            # All columns that are not part of the natural key will be updated on conflict.
-            update_cols = ", ".join(
-                f'"{col}" = EXCLUDED."{col}"' for col in columns if col not in conflict_keys
-            )
+            # For parent tables (studies, raw_studies), use UPSERT logic.
+            # For child tables, use DELETE/INSERT.
+            # The caller (transformer) is responsible for knowing which tables are which.
+            # A simple heuristic is that parent tables have a single-column PK.
+            is_parent_table = len(primary_keys) == 1
 
-            # If all columns are part of the natural key, there's nothing to update.
-            on_conflict_action = "DO NOTHING" if not update_cols else f"DO UPDATE SET {update_cols}"
+            if is_parent_table:
+                conflict_target = ", ".join(f'"{pk}"' for pk in primary_keys)
+                update_cols = ", ".join(
+                    f'"{col}" = EXCLUDED."{col}"'
+                    for col in columns
+                    if col not in primary_keys
+                )
+                on_conflict_action = (
+                    "DO NOTHING" if not update_cols else f"DO UPDATE SET {update_cols}"
+                )
 
-            # First, for child tables, we must clear old records for the studies being updated.
-            # This is necessary because we are replacing the entire set of child records for a study.
-            if table_name not in ["studies", "raw_studies"]:
-                cur.execute(f"""
-                    DELETE FROM {table_name}
-                    WHERE nct_id IN (SELECT DISTINCT nct_id FROM {staging_table_name})
-                """)
-
-            # Now, insert all the new records from the staging table.
-            # Since we deleted the old ones, this is a simple insert.
-            # The previous logic was flawed. A true UPSERT is not what is needed for these
-            # child tables, as we want to replace the entire collection.
-            # The correct pattern for "replace-all-child-records" is DELETE then INSERT.
-            # The `ON CONFLICT` is for the parent `studies` table.
-
-            if table_name in ["studies", "raw_studies"]:
-                 merge_sql = f"""
+                merge_sql = f"""
                     INSERT INTO {table_name} ({col_names})
                     SELECT {col_names} FROM {staging_table_name}
                     ON CONFLICT ({conflict_target}) {on_conflict_action}
                 """
             else:
-                # For child tables, we've already deleted, so we just insert.
+                # For child tables, clear old records for the studies being updated.
+                # This is necessary to replace the entire set of child records for a study.
+                cur.execute(f"""
+                    DELETE FROM {table_name}
+                    WHERE nct_id IN (SELECT DISTINCT nct_id FROM {staging_table_name})
+                """)
+
+                # After deleting, perform a simple INSERT.
                 merge_sql = f"""
                     INSERT INTO {table_name} ({col_names})
                     SELECT {col_names} FROM {staging_table_name}

--- a/tests/integration/test_full_etl.py
+++ b/tests/integration/test_full_etl.py
@@ -36,11 +36,11 @@ def test_full_etl_flow(db_connector):
 
     # Load initial data
     db_connector.bulk_load_staging("studies", studies_df)
-    db_connector.execute_merge("studies")
+    db_connector.execute_merge("studies", primary_keys=["nct_id"])
     db_connector.bulk_load_staging("interventions", interventions_df)
-    db_connector.execute_merge("interventions")
+    db_connector.execute_merge("interventions", primary_keys=["nct_id", "intervention_type", "name"])
     db_connector.bulk_load_staging("design_outcomes", outcomes_df)
-    db_connector.execute_merge("design_outcomes")
+    db_connector.execute_merge("design_outcomes", primary_keys=["nct_id", "outcome_type", "measure"])
 
     # Verify initial load
     with db_connector.conn.cursor() as cur:
@@ -62,9 +62,9 @@ def test_full_etl_flow(db_connector):
 
     # Load updated data
     db_connector.bulk_load_staging("studies", updated_studies_df)
-    db_connector.execute_merge("studies")
+    db_connector.execute_merge("studies", primary_keys=["nct_id"])
     db_connector.bulk_load_staging("interventions", updated_interventions_df)
-    db_connector.execute_merge("interventions")
+    db_connector.execute_merge("interventions", primary_keys=["nct_id", "intervention_type", "name"])
 
     # Verify the update
     with db_connector.conn.cursor() as cur:


### PR DESCRIPTION
…trategy Pattern and the principles outlined in the FRD.

The responsibility for defining table primary keys has been moved from the database-specific `PostgresConnector` to the higher-level ETL orchestrator in `cli.py`.

Changes:
- The `DatabaseConnectorInterface` for `execute_merge` was updated to accept a list of primary key columns.
- The `PostgresConnector` was updated to implement this new interface, using the provided keys to dynamically build its merge/upsert logic instead of relying on a hardcoded internal dictionary.
- The orchestration logic in `cli.py` now defines the primary keys for each table and passes them to the connector.
- Integration tests were updated to reflect the new method signature.

This change makes the connector more generic and abstract, making it easier to add new database connectors in the future without duplicating schema-specific logic.