### PR TITLE
Refactor: Introduce Orchestrator and Improve Test Suite

### DIFF
--- a/alembic/versions/306262f13a15_add_last_updated_api_str_to_raw_studies.py
+++ b/alembic/versions/306262f13a15_add_last_updated_api_str_to_raw_studies.py
@@ -1,0 +1,28 @@
+"""add last_updated_api_str to raw_studies
+
+Revision ID: 306262f13a15
+Revises: 88c6978d6685
+Create Date: 2025-09-07 16:39:53.057469
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '306262f13a15'
+down_revision: Union[str, Sequence[str], None] = '88c6978d6685'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('raw_studies', sa.Column('last_updated_api_str', sa.String(length=255), nullable=True))
+    op.add_column('staging_raw_studies', sa.Column('last_updated_api_str', sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('staging_raw_studies', 'last_updated_api_str')
+    op.drop_column('raw_studies', 'last_updated_api_str')

--- a/src/py_load_clinicaltrialsgov/cli.py
+++ b/src/py_load_clinicaltrialsgov/cli.py
@@ -8,7 +8,7 @@ from py_load_clinicaltrialsgov.connectors.postgres import PostgresConnector
 from py_load_clinicaltrialsgov.connectors.interface import DatabaseConnectorInterface
 from py_load_clinicaltrialsgov.extractor.api_client import APIClient
 from py_load_clinicaltrialsgov.transformer.transformer import Transformer
-from py_load_clinicaltrialsgov.config import settings
+from py_load_clinicaltrialsgov.orchestrator import Orchestrator
 
 
 # Configure structlog for JSON output
@@ -37,99 +37,27 @@ def get_connector(name: str) -> DatabaseConnectorInterface:
     logger.error("unsupported_connector", connector_name=name)
     raise ValueError(f"Unsupported connector: {name}")
 
+
 @app.command()
 def run(
-    load_type: Annotated[str, typer.Option(help="Type of load: 'full' or 'delta'.")] = "delta",
-    connector_name: Annotated[str, typer.Option(help="Name of the database connector to use.")] = "postgres",
+    load_type: Annotated[
+        str, typer.Option(help="Type of load: 'full' or 'delta'.")
+    ] = "delta",
+    connector_name: Annotated[
+        str, typer.Option(help="Name of the database connector to use.")
+    ] = "postgres",
 ):
     """
     Run the ETL process.
     """
-    log = logger.bind(load_type=load_type, connector_name=connector_name)
-    log.info("etl_process_started")
-
     connector = get_connector(connector_name)
     api_client = APIClient()
     transformer = Transformer()
 
-    try:
-        connector.manage_transaction("begin")
-
-        updated_since = None
-        if load_type == "delta":
-            updated_since = connector.get_last_successful_load_timestamp()
-            if updated_since:
-                log.info("delta_load_initiated", updated_since=updated_since.isoformat())
-            else:
-                log.info("no_successful_load_found_performing_full_load")
-
-        studies_iterator = api_client.get_all_studies(updated_since=updated_since)
-
-        record_count = 0
-        for study in studies_iterator:
-            nct_id = study.protocol_section.identification_module.get("nctId")
-            try:
-                transformer.transform_study(study)
-                record_count += 1
-                if record_count % 100 == 0:
-                    log.info("processed_studies_batch", record_count=record_count)
-            except Exception as e:
-                log.error(
-                    "study_transformation_failed",
-                    nct_id=nct_id,
-                    error=str(e),
-                    exc_info=True,
-                )
-                if nct_id:
-                    connector.record_failed_study(
-                        nct_id=nct_id,
-                        payload=study.model_dump(),
-                        error_message=str(e),
-                    )
-
-        log.info("finished_processing_studies", total_record_count=record_count)
-
-        # This metadata now lives in the orchestrator, not the connector.
-        table_metadata = {
-            "raw_studies": ["nct_id"],
-            "studies": ["nct_id"],
-            "sponsors": ["nct_id", "name", "agency_class"],
-            "conditions": ["nct_id", "name"],
-            "interventions": ["nct_id", "intervention_type", "name"],
-            "design_outcomes": ["nct_id", "outcome_type", "measure"],
-        }
-
-        dataframes = transformer.get_dataframes()
-        for table_name, df in dataframes.items():
-            if not df.empty:
-                log.info(
-                    "loading_data_into_table",
-                    table_name=table_name,
-                    record_count=len(df),
-                )
-                primary_keys = table_metadata.get(table_name)
-                if not primary_keys:
-                    log.error("no_primary_key_defined_for_table", table_name=table_name)
-                    # Optionally, raise an error or skip the table
-                    continue
-
-                connector.bulk_load_staging(table_name, df)
-                connector.execute_merge(table_name, primary_keys)
-
-        metrics = {"records_processed": record_count}
-        connector.record_load_history("SUCCESS", metrics)
-        connector.manage_transaction("commit")
-        log.info("etl_process_completed_successfully", metrics=metrics)
-
-    except Exception as e:
-        log.error("etl_process_failed", error=str(e), exc_info=True)
-        if 'connector' in locals():
-            connector.manage_transaction("rollback")
-            metrics = {"error": str(e)}
-            connector.record_load_history("FAILURE", metrics)
-    finally:
-        if 'api_client' in locals():
-            api_client.close()
+    orchestrator = Orchestrator(
+        connector=connector, api_client=api_client, transformer=transformer
+    )
+    orchestrator.run_etl(load_type=load_type)
 
 from alembic.config import Config
 from alembic import command

--- a/src/py_load_clinicaltrialsgov/orchestrator.py
+++ b/src/py_load_clinicaltrialsgov/orchestrator.py
@@ -1,0 +1,117 @@
+import structlog
+from typing import Dict, List, Any
+
+from py_load_clinicaltrialsgov.connectors.interface import DatabaseConnectorInterface
+from py_load_clinicaltrialsgov.extractor.api_client import APIClient
+from py_load_clinicaltrialsgov.transformer.transformer import Transformer
+
+logger = structlog.get_logger(__name__)
+
+
+class Orchestrator:
+    """
+    Orchestrates the ETL process from extraction to loading.
+    """
+
+    TABLE_METADATA: Dict[str, List[str]] = {
+        "raw_studies": ["nct_id"],
+        "studies": ["nct_id"],
+        "sponsors": ["nct_id", "name", "agency_class"],
+        "conditions": ["nct_id", "name"],
+        "interventions": ["nct_id", "intervention_type", "name"],
+        "design_outcomes": ["nct_id", "outcome_type", "measure"],
+    }
+
+    def __init__(
+        self,
+        connector: DatabaseConnectorInterface,
+        api_client: APIClient,
+        transformer: Transformer,
+    ):
+        self.connector = connector
+        self.api_client = api_client
+        self.transformer = transformer
+
+    def run_etl(self, load_type: str):
+        """
+        Executes the full ETL pipeline.
+        """
+        log = logger.bind(load_type=load_type)
+        log.info("etl_process_started")
+
+        try:
+            self.connector.manage_transaction("begin")
+
+            updated_since = None
+            if load_type == "delta":
+                updated_since = self.connector.get_last_successful_load_timestamp()
+                if updated_since:
+                    log.info(
+                        "delta_load_initiated",
+                        updated_since=updated_since.isoformat(),
+                    )
+                else:
+                    log.info("no_successful_load_found_performing_full_load")
+
+            studies_iterator = self.api_client.get_all_studies(
+                updated_since=updated_since
+            )
+
+            record_count = 0
+            for study in studies_iterator:
+                nct_id = (
+                    study.protocol_section.identification_module.get("nctId")
+                    if study.protocol_section.identification_module
+                    else None
+                )
+                try:
+                    self.transformer.transform_study(study)
+                    record_count += 1
+                    if record_count % 100 == 0:
+                        log.info("processed_studies_batch", record_count=record_count)
+                except Exception as e:
+                    log.error(
+                        "study_transformation_failed",
+                        nct_id=nct_id,
+                        error=str(e),
+                        exc_info=True,
+                    )
+                    if nct_id:
+                        self.connector.record_failed_study(
+                            nct_id=nct_id,
+                            payload=study.model_dump(),
+                            error_message=str(e),
+                        )
+
+            log.info("finished_processing_studies", total_record_count=record_count)
+
+            dataframes = self.transformer.get_dataframes()
+            for table_name, df in dataframes.items():
+                if not df.empty:
+                    log.info(
+                        "loading_data_into_table",
+                        table_name=table_name,
+                        record_count=len(df),
+                    )
+                    primary_keys = self.TABLE_METADATA.get(table_name)
+                    if not primary_keys:
+                        log.error(
+                            "no_primary_key_defined_for_table", table_name=table_name
+                        )
+                        continue
+
+                    self.connector.bulk_load_staging(table_name, df)
+                    self.connector.execute_merge(table_name, primary_keys)
+
+            metrics: Dict[str, Any] = {"records_processed": record_count}
+            self.connector.record_load_history("SUCCESS", metrics)
+            self.connector.manage_transaction("commit")
+            log.info("etl_process_completed_successfully", metrics=metrics)
+
+        except Exception as e:
+            log.error("etl_process_failed", error=str(e), exc_info=True)
+            self.connector.manage_transaction("rollback")
+            metrics = {"error": str(e)}
+            self.connector.record_load_history("FAILURE", metrics)
+        finally:
+            self.api_client.close()

--- a/src/py_load_clinicaltrialsgov/sql/schema.sql
+++ b/src/py_load_clinicaltrialsgov/sql/schema.sql
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS dead_letter_queue (
     nct_id VARCHAR(255),
     payload JSONB,
     error_message TEXT,
-    created_at TIMESTAMETZ DEFAULT now()
+    created_at TIMESTAMPTZ DEFAULT now()
 );
 
 CREATE TABLE IF NOT EXISTS load_history (

--- a/src/py_load_clinicaltrialsgov/transformer/transformer.py
+++ b/src/py_load_clinicaltrialsgov/transformer/transformer.py
@@ -38,14 +38,19 @@ class Transformer:
     def _transform_raw_studies(self, nct_id: str, study: Study):
         last_updated_str = None
         if study.protocol_section.status_module:
-            last_updated_str = study.protocol_section.status_module.get("lastUpdatePostDateStruct", {}).get("date")
+            last_updated_str = study.protocol_section.status_module.get(
+                "lastUpdatePostDateStruct", {}
+            ).get("date")
 
-        self.raw_studies.append({
-            "nct_id": nct_id,
-            "last_updated_api": self._normalize_date(last_updated_str),
-            "ingestion_timestamp": datetime.now(UTC),
-            "payload": study.model_dump_json(by_alias=True)
-        })
+        self.raw_studies.append(
+            {
+                "nct_id": nct_id,
+                "last_updated_api": self._normalize_date(last_updated_str),
+                "last_updated_api_str": last_updated_str,
+                "ingestion_timestamp": datetime.now(UTC),
+                "payload": study.model_dump_json(by_alias=True),
+            }
+        )
 
     def _transform_studies_table(self, nct_id: str, study: Study):
         start_date_str = None

--- a/tests/integration/test_full_etl.py
+++ b/tests/integration/test_full_etl.py
@@ -5,18 +5,36 @@ from py_load_clinicaltrialsgov.connectors.postgres import PostgresConnector
 from py_load_clinicaltrialsgov.config import settings
 from datetime import datetime
 
+from alembic.config import Config
+from alembic import command
+
 @pytest.fixture(scope="module")
 def postgres_container():
-    with PostgresContainer("postgres:13") as container:
+    with PostgresContainer("postgres:latest", driver=None) as container:
         original_dsn = settings.db.dsn
-        settings.db.dsn = container.get_connection_url()
+
+        # The plain DSN for the application
+        app_dsn = container.get_connection_url()
+        # The DSN with the correct dialect for Alembic/SQLAlchemy
+        alembic_dsn = app_dsn.replace("postgresql://", "postgresql+psycopg://")
+
+        # Set DSN for Alembic and run migrations
+        settings.db.dsn = alembic_dsn
+        alembic_cfg = Config("alembic.ini")
+        command.upgrade(alembic_cfg, "head")
+
+        # Set DSN for the application to use
+        settings.db.dsn = app_dsn
         yield container
+
+        # Restore original DSN after tests
         settings.db.dsn = original_dsn
+
 
 @pytest.fixture(scope="module")
 def db_connector(postgres_container):
+    # The DSN is already set correctly by the postgres_container fixture
     connector = PostgresConnector()
-    connector.initialize_schema()
     return connector
 
 def test_full_etl_flow(db_connector):
@@ -25,7 +43,20 @@ def test_full_etl_flow(db_connector):
     including the "delete then insert" logic for child tables.
     """
     # 1. Initial Load
-    studies_df = pd.DataFrame([{"nct_id": "NCT00000123", "brief_title": "Initial Title", "study_type": "Observational"}])
+    studies_columns = [
+        "nct_id", "brief_title", "official_title", "overall_status", "start_date",
+        "start_date_str", "primary_completion_date", "primary_completion_date_str",
+        "study_type", "brief_summary"
+    ]
+    studies_df = pd.DataFrame(
+        [
+            (
+                "NCT00000123", "Initial Title", None, "COMPLETED", None,
+                None, None, None, "Observational", None
+            )
+        ],
+        columns=studies_columns
+    )
     interventions_df = pd.DataFrame([
         {"nct_id": "NCT00000123", "intervention_type": "DRUG", "name": "Aspirin", "description": "Low dose aspirin"},
         {"nct_id": "NCT00000123", "intervention_type": "DRUG", "name": "Placebo", "description": "Sugar pill"}
@@ -55,7 +86,15 @@ def test_full_etl_flow(db_connector):
 
     # 2. Second Load (Delta update for the same study)
     # The title is updated, and the interventions have changed completely.
-    updated_studies_df = pd.DataFrame([{"nct_id": "NCT00000123", "brief_title": "Updated Title", "study_type": "Observational"}])
+    updated_studies_df = pd.DataFrame(
+        [
+            (
+                "NCT00000123", "Updated Title", None, "COMPLETED", None,
+                None, None, None, "Observational", None
+            )
+        ],
+        columns=studies_columns
+    )
     updated_interventions_df = pd.DataFrame([
         {"nct_id": "NCT00000123", "intervention_type": "DEVICE", "name": "Stent", "description": "A new device"}
     ])


### PR DESCRIPTION
This commit addresses several gaps identified from the FRD.

1.  **Refactor ETL Orchestration:**
    - The core ETL logic has been moved from the `run` function in `cli.py` to a new, dedicated `Orchestrator` class in `src/py_load_clinicaltrialsgov/orchestrator.py`.
    - The `cli.py` `run` command is now a thin wrapper that instantiates and calls the orchestrator, improving separation of concerns and testability.

2.  **Add Date String Storage for Consistency (REQ 4.4.2):**
    - To consistently store original date strings, a `last_updated_api_str` column has been added to the `raw_studies` table.
    - A new Alembic migration (`306262f13a15`) is added to apply this schema change.
    - The `Transformer` is updated to populate this new field.

3.  **Improve Integration Test Suite:**
    - The integration test fixture now correctly initializes the test database by running all Alembic migrations, ensuring tests run against a production-like schema.
    - Fixed a bug in the test data where DataFrames had incomplete columns, causing `COPY` errors.
    - Addressed multiple environment-specific issues related to Docker permissions (`sudo`), Docker Hub rate limits (`postgres:latest`), and database driver dialects (`driver=None`, `postgresql+psycopg://`).

4.  **Fix Schema Typo:**
    - Corrected a typo in `schema.sql` from `TIMESTAMETZ` to the valid `TIMESTAMPTZ` type.