### PR TITLE
feat: Improve full load and refactor merge logic

### DIFF
--- a/src/py_load_clinicaltrialsgov/connectors/interface.py
+++ b/src/py_load_clinicaltrialsgov/connectors/interface.py
@@ -19,6 +19,11 @@ class DatabaseConnectorInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def truncate_all_tables(self) -> None:
+        """Truncate all main data tables."""
+        raise NotImplementedError
+
+    @abstractmethod
     def get_last_successful_load_history(self) -> Dict[str, Any] | None:
         """
         Retrieve the most recent successful entry from the load history.
@@ -41,12 +46,7 @@ class DatabaseConnectorInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def execute_merge(
-        self,
-        table_name: str,
-        primary_keys: List[str],
-        strategy: Literal["upsert", "delete_insert"],
-    ) -> None:
+    def execute_merge(self, table_name: str, primary_keys: List[str]) -> None:
         """
         Perform an UPSERT/MERGE from a staging table to the final table.
 
@@ -54,8 +54,6 @@ class DatabaseConnectorInterface(ABC):
             table_name: The name of the final target table.
             primary_keys: A list of column names that form the natural
                           primary key for the merge operation.
-            strategy: The merge strategy to use ('upsert' for parent tables,
-                      'delete_insert' for child tables).
         """
         raise NotImplementedError
 

--- a/src/py_load_clinicaltrialsgov/connectors/postgres.py
+++ b/src/py_load_clinicaltrialsgov/connectors/postgres.py
@@ -31,6 +31,26 @@ class PostgresConnector(DatabaseConnectorInterface):
         """
         pass
 
+    def truncate_all_tables(self) -> None:
+        """
+        Truncates all data tables in the schema.
+        """
+        tables_to_truncate = [
+            "raw_studies",
+            "studies",
+            "sponsors",
+            "conditions",
+            "interventions",
+            "design_outcomes",
+        ]
+        with self.conn.cursor() as cur:
+            # TRUNCATE is a DDL command and runs in its own transaction.
+            # We use RESTART IDENTITY to reset any auto-incrementing counters.
+            # We use CASCADE to drop dependent objects, though none are expected.
+            cur.execute(
+                f"TRUNCATE TABLE {', '.join(tables_to_truncate)} RESTART IDENTITY CASCADE"
+            )
+
     def bulk_load_staging(self, table_name: str, data: pd.DataFrame) -> None:
         """
         Bulk loads a DataFrame into a staging table using the COPY protocol.
@@ -53,17 +73,20 @@ class PostgresConnector(DatabaseConnectorInterface):
             ) as copy:
                 copy.write(csv_buffer.read())
 
-    def execute_merge(
-        self,
-        table_name: str,
-        primary_keys: List[str],
-        strategy: Literal["upsert", "delete_insert"],
-    ) -> None:
+    def execute_merge(self, table_name: str, primary_keys: List[str]) -> None:
         """
-        Merges data from a staging table to a final table using either a pure
-        UPSERT strategy or a DELETE/INSERT strategy.
+        Merges data from a staging table to a final table.
+        It internally decides the merge strategy.
+        - 'upsert' for parent tables ('studies', 'raw_studies').
+        - 'delete_insert' for child tables.
         """
         staging_table_name = f"staging_{table_name}"
+
+        # Determine strategy based on table name
+        if table_name in ["studies", "raw_studies"]:
+            strategy = "upsert"
+        else:
+            strategy = "delete_insert"
 
         with self.conn.cursor() as cur:
             cur.execute(
@@ -85,7 +108,6 @@ class PostgresConnector(DatabaseConnectorInterface):
                 if not update_cols:
                     on_conflict_action = "DO NOTHING"
                 else:
-                    # Create the "col" = EXCLUDED."col" part for each column
                     update_assignments = [
                         f'"{col}" = EXCLUDED."{col}"' for col in update_cols
                     ]
@@ -108,8 +130,6 @@ class PostgresConnector(DatabaseConnectorInterface):
                     INSERT INTO {table_name} ({col_names})
                     SELECT {col_names} FROM {staging_table_name};
                 """
-            else:
-                raise ValueError(f"Unknown merge strategy: {strategy}")
 
             cur.execute(merge_sql)
 

--- a/src/py_load_clinicaltrialsgov/orchestrator.py
+++ b/src/py_load_clinicaltrialsgov/orchestrator.py
@@ -42,10 +42,12 @@ class Orchestrator:
         log.info("etl_process_started")
 
         try:
-            self.connector.manage_transaction("begin")
-
+            # Handle load type specific setup before starting the transaction
             updated_since = None
-            if load_type == "delta":
+            if load_type == "full":
+                log.info("full_load_initiated_truncating_tables")
+                self.connector.truncate_all_tables()
+            elif load_type == "delta":
                 updated_since = self.connector.get_last_successful_load_timestamp()
                 if updated_since:
                     log.info(
@@ -54,6 +56,9 @@ class Orchestrator:
                     )
                 else:
                     log.info("no_successful_load_found_performing_full_load")
+
+            # Start the main transaction for the ETL run
+            self.connector.manage_transaction("begin")
 
             studies_iterator = self.api_client.get_all_studies(
                 updated_since=updated_since
@@ -106,15 +111,7 @@ class Orchestrator:
                         continue
 
                     self.connector.bulk_load_staging(table_name, df)
-
-                    # Parent tables use 'upsert', child tables use 'delete_insert'
-                    # to ensure the full set of child records is replaced.
-                    is_parent_table = primary_keys == ["nct_id"]
-                    strategy: Literal["upsert", "delete_insert"] = (
-                        "upsert" if is_parent_table else "delete_insert"
-                    )
-
-                    self.connector.execute_merge(table_name, primary_keys, strategy)
+                    self.connector.execute_merge(table_name, primary_keys)
 
             duration = time.time() - start_time
             metrics: Dict[str, Any] = {

--- a/src/py_load_clinicaltrialsgov/sql/schema.sql
+++ b/src/py_load_clinicaltrialsgov/sql/schema.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS raw_studies (
     nct_id VARCHAR(255) PRIMARY KEY,
     last_updated_api TIMESTAMP,
+    last_updated_api_str VARCHAR(255),
     ingestion_timestamp TIMESTAMP,
     payload JSONB
 );
@@ -74,6 +75,7 @@ CREATE TABLE IF NOT EXISTS load_history (
 CREATE UNLOGGED TABLE IF NOT EXISTS staging_raw_studies (
     nct_id VARCHAR(255),
     last_updated_api TIMESTAMP,
+    last_updated_api_str VARCHAR(255),
     ingestion_timestamp TIMESTAMP,
     payload JSONB
 );


### PR DESCRIPTION
This commit introduces two main improvements to the ETL process to better align with the FRD.

First, it implements table truncation for full loads (REQ 3.3.1.2). A `truncate_all_tables` method was added to the database connector and is called by the orchestrator at the start of a `full` load. This ensures a clean slate and prevents data from previous loads from persisting incorrectly.

Second, it refactors the merge strategy logic (REQ 5.4.3, REQ 2.1.1). The responsibility for choosing the merge strategy has been moved from the orchestrator to the database connector. This makes the core ETL logic more database-agnostic and improves the modularity of the system.

Finally, the `raw_studies` table definition in the base `schema.sql` was updated to include the `last_updated_api_str` column, aligning it with the data being produced by the transformer and an existing migration.