### PR TITLE
feat: Add ETL for location and eligibility data

### DIFF
--- a/alembic/versions/306262f13a15_add_last_updated_api_str_to_raw_studies.py
+++ b/alembic/versions/306262f13a15_add_last_updated_api_str_to_raw_studies.py
@@ -8,8 +8,6 @@ Create Date: 2025-09-07 16:39:53.057469
 
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/e4bc992b21e8_add_unique_constraints_to_child_tables.py
+++ b/alembic/versions/e4bc992b21e8_add_unique_constraints_to_child_tables.py
@@ -7,8 +7,6 @@ Create Date: 2025-09-08 12:19:56.004990
 """
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/fd9eb973ece2_add_locations_and_eligibility_tables.py
+++ b/alembic/versions/fd9eb973ece2_add_locations_and_eligibility_tables.py
@@ -1,0 +1,68 @@
+"""add_locations_and_eligibility_tables
+
+Revision ID: fd9eb973ece2
+Revises: e4bc992b21e8
+Create Date: 2025-09-09 10:36:45.169777
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'fd9eb973ece2'
+down_revision: Union[str, Sequence[str], None] = 'e4bc992b21e8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE TABLE IF NOT EXISTS eligibility_criteria (
+        nct_id VARCHAR(255) PRIMARY KEY,
+        sex VARCHAR(255),
+        minimum_age VARCHAR(255),
+        maximum_age VARCHAR(255),
+        criteria TEXT
+    );
+    """)
+    op.execute("""
+    CREATE UNLOGGED TABLE IF NOT EXISTS staging_eligibility_criteria (
+        nct_id VARCHAR(255),
+        sex VARCHAR(255),
+        minimum_age VARCHAR(255),
+        maximum_age VARCHAR(255),
+        criteria TEXT
+    );
+    """)
+    op.execute("""
+    CREATE TABLE IF NOT EXISTS locations (
+        id SERIAL PRIMARY KEY,
+        nct_id VARCHAR(255) NOT NULL,
+        city VARCHAR(255),
+        state VARCHAR(255),
+        zip VARCHAR(255),
+        country VARCHAR(255),
+        CONSTRAINT uq_locations_natural_key UNIQUE (nct_id, city, state, country)
+    );
+    """)
+    op.execute("""
+    CREATE INDEX IF NOT EXISTS idx_locations_nct_id ON locations(nct_id);
+    """)
+    op.execute("""
+    CREATE UNLOGGED TABLE IF NOT EXISTS staging_locations (
+        nct_id VARCHAR(255),
+        city VARCHAR(255),
+        state VARCHAR(255),
+        zip VARCHAR(255),
+        country VARCHAR(255)
+    );
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS locations CASCADE;")
+    op.execute("DROP TABLE IF EXISTS eligibility_criteria CASCADE;")
+    op.execute("DROP TABLE IF EXISTS staging_locations CASCADE;")
+    op.execute("DROP TABLE IF EXISTS staging_eligibility_criteria CASCADE;")

--- a/src/py_load_clinicaltrialsgov/models/api_models.py
+++ b/src/py_load_clinicaltrialsgov/models/api_models.py
@@ -76,6 +76,24 @@ class DesignModule(BaseModel):
     study_type: Optional[str] = Field(None, alias="studyType")
 
 
+class EligibilityModule(BaseModel):
+    sex: Optional[str] = None
+    minimum_age: Optional[str] = Field(None, alias="minimumAge")
+    maximum_age: Optional[str] = Field(None, alias="maximumAge")
+    criteria: Optional[str] = None
+
+
+class Location(BaseModel):
+    city: Optional[str] = None
+    state: Optional[str] = None
+    zip: Optional[str] = None
+    country: Optional[str] = None
+
+
+class ContactsLocationsModule(BaseModel):
+    locations: Optional[List[Location]] = None
+
+
 class ProtocolSection(BaseModel):
     identification_module: IdentificationModule = Field(
         ..., alias="identificationModule"
@@ -96,10 +114,10 @@ class ProtocolSection(BaseModel):
         None, alias="armsInterventionsModule"
     )
     outcomes_module: Optional[OutcomesModule] = Field(None, alias="outcomesModule")
-    eligibility_module: Optional[dict[str, Any]] = Field(
+    eligibility_module: Optional[EligibilityModule] = Field(
         None, alias="eligibilityModule"
     )
-    contacts_locations_module: Optional[dict[str, Any]] = Field(
+    contacts_locations_module: Optional[ContactsLocationsModule] = Field(
         None, alias="contactsLocationsModule"
     )
     references_module: Optional[dict[str, Any]] = Field(None, alias="referencesModule")

--- a/src/py_load_clinicaltrialsgov/orchestrator.py
+++ b/src/py_load_clinicaltrialsgov/orchestrator.py
@@ -25,6 +25,8 @@ class Orchestrator:
         "conditions": ["nct_id", "name"],
         "interventions": ["nct_id", "intervention_type", "name"],
         "design_outcomes": ["nct_id", "outcome_type", "measure"],
+        "eligibility_criteria": ["nct_id"],
+        "locations": ["nct_id", "city", "state", "country"],
     }
 
     def __init__(

--- a/src/py_load_clinicaltrialsgov/sql/schema.sql
+++ b/src/py_load_clinicaltrialsgov/sql/schema.sql
@@ -58,6 +58,25 @@ CREATE TABLE IF NOT EXISTS design_outcomes (
 );
 CREATE INDEX IF NOT EXISTS idx_design_outcomes_nct_id ON design_outcomes(nct_id);
 
+CREATE TABLE IF NOT EXISTS eligibility_criteria (
+    nct_id VARCHAR(255) PRIMARY KEY,
+    sex VARCHAR(255),
+    minimum_age VARCHAR(255),
+    maximum_age VARCHAR(255),
+    criteria TEXT
+);
+
+CREATE TABLE IF NOT EXISTS locations (
+    id SERIAL PRIMARY KEY,
+    nct_id VARCHAR(255) NOT NULL,
+    city VARCHAR(255),
+    state VARCHAR(255),
+    zip VARCHAR(255),
+    country VARCHAR(255),
+    CONSTRAINT uq_locations_natural_key UNIQUE (nct_id, city, state, country)
+);
+CREATE INDEX IF NOT EXISTS idx_locations_nct_id ON locations(nct_id);
+
 
 CREATE TABLE IF NOT EXISTS dead_letter_queue (
     id SERIAL PRIMARY KEY,
@@ -122,4 +141,20 @@ CREATE UNLOGGED TABLE IF NOT EXISTS staging_design_outcomes (
     measure TEXT,
     time_frame TEXT,
     description TEXT
+);
+
+CREATE UNLOGGED TABLE IF NOT EXISTS staging_eligibility_criteria (
+    nct_id VARCHAR(255),
+    sex VARCHAR(255),
+    minimum_age VARCHAR(255),
+    maximum_age VARCHAR(255),
+    criteria TEXT
+);
+
+CREATE UNLOGGED TABLE IF NOT EXISTS staging_locations (
+    nct_id VARCHAR(255),
+    city VARCHAR(255),
+    state VARCHAR(255),
+    zip VARCHAR(255),
+    country VARCHAR(255)
 );

--- a/src/py_load_clinicaltrialsgov/transformer/transformer.py
+++ b/src/py_load_clinicaltrialsgov/transformer/transformer.py
@@ -21,6 +21,8 @@ class Transformer:
         self.conditions: List[Dict[str, Any]] = []
         self.interventions: List[Dict[str, Any]] = []
         self.design_outcomes: List[Dict[str, Any]] = []
+        self.eligibility_criteria: List[Dict[str, Any]] = []
+        self.locations: List[Dict[str, Any]] = []
 
     def transform_study(self, study: Study, raw_study_payload: Dict[str, Any]) -> None:
         """
@@ -41,6 +43,8 @@ class Transformer:
         self._transform_conditions(nct_id, study)
         self._transform_interventions(nct_id, study)
         self._transform_outcomes(nct_id, study)
+        self._transform_eligibility(nct_id, study)
+        self._transform_locations(nct_id, study)
 
     def _transform_raw_studies(
         self, nct_id: str, raw_payload: Dict[str, Any], study: Study
@@ -178,6 +182,37 @@ class Transformer:
                     }
                 )
 
+    def _transform_eligibility(self, nct_id: str, study: Study) -> None:
+        module = study.protocol_section.eligibility_module
+        if not module:
+            return
+
+        self.eligibility_criteria.append(
+            {
+                "nct_id": nct_id,
+                "sex": module.sex,
+                "minimum_age": module.minimum_age,
+                "maximum_age": module.maximum_age,
+                "criteria": module.criteria,
+            }
+        )
+
+    def _transform_locations(self, nct_id: str, study: Study) -> None:
+        module = study.protocol_section.contacts_locations_module
+        if not module or not module.locations:
+            return
+
+        for location in module.locations:
+            self.locations.append(
+                {
+                    "nct_id": nct_id,
+                    "city": location.city,
+                    "state": location.state,
+                    "zip": location.zip,
+                    "country": location.country,
+                }
+            )
+
     def _normalize_date(self, date_str: str | None) -> datetime | None:
         if not date_str:
             return None
@@ -195,6 +230,8 @@ class Transformer:
             "conditions": pd.DataFrame(self.conditions),
             "interventions": pd.DataFrame(self.interventions),
             "design_outcomes": pd.DataFrame(self.design_outcomes),
+            "eligibility_criteria": pd.DataFrame(self.eligibility_criteria),
+            "locations": pd.DataFrame(self.locations),
         }
         return {name: df for name, df in dataframes.items() if not df.empty}
 
@@ -205,3 +242,5 @@ class Transformer:
         self.conditions.clear()
         self.interventions.clear()
         self.design_outcomes.clear()
+        self.eligibility_criteria.clear()
+        self.locations.clear()

--- a/tests/integration/test_full_etl.py
+++ b/tests/integration/test_full_etl.py
@@ -116,6 +116,35 @@ def test_full_etl_flow(db_connector: DatabaseConnectorInterface) -> None:
             }
         ]
     )
+    eligibility_df = pd.DataFrame(
+        [
+            {
+                "nct_id": "NCT00000123",
+                "sex": "ALL",
+                "minimum_age": "18 Years",
+                "maximum_age": "65 Years",
+                "criteria": "Some criteria",
+            }
+        ]
+    )
+    locations_df = pd.DataFrame(
+        [
+            {
+                "nct_id": "NCT00000123",
+                "city": "New York",
+                "state": "New York",
+                "zip": "10001",
+                "country": "United States",
+            },
+            {
+                "nct_id": "NCT00000123",
+                "city": "Boston",
+                "state": "Massachusetts",
+                "zip": "02110",
+                "country": "United States",
+            },
+        ]
+    )
 
     # Load initial data
     db_connector.bulk_load_staging("studies", studies_df)
@@ -128,19 +157,41 @@ def test_full_etl_flow(db_connector: DatabaseConnectorInterface) -> None:
     db_connector.execute_merge(
         "design_outcomes", primary_keys=["nct_id", "outcome_type", "measure"]
     )
+    db_connector.bulk_load_staging("eligibility_criteria", eligibility_df)
+    db_connector.execute_merge("eligibility_criteria", primary_keys=["nct_id"])
+    db_connector.bulk_load_staging("locations", locations_df)
+    db_connector.execute_merge(
+        "locations", primary_keys=["nct_id", "city", "state", "country"]
+    )
 
     # Verify initial load
     with pg_connector.conn.cursor() as cur:
         cur.execute("SELECT COUNT(*) FROM studies WHERE nct_id = 'NCT00000123'")
-        assert cur.fetchone()[0] == 1
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
         cur.execute("SELECT COUNT(*) FROM interventions WHERE nct_id = 'NCT00000123'")
-        assert cur.fetchone()[0] == 2
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 2
         cur.execute("SELECT COUNT(*) FROM design_outcomes WHERE nct_id = 'NCT00000123'")
-        assert cur.fetchone()[0] == 1
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
         cur.execute(
             "SELECT name FROM interventions WHERE nct_id = 'NCT00000123' AND name = 'Aspirin'"
         )
         assert cur.fetchone() is not None
+        cur.execute(
+            "SELECT COUNT(*) FROM eligibility_criteria WHERE nct_id = 'NCT00000123'"
+        )
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
+        cur.execute("SELECT COUNT(*) FROM locations WHERE nct_id = 'NCT00000123'")
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 2
 
     # 2. Second Load (Delta update for the same study)
     # The title is updated, and the interventions have changed completely.
@@ -171,6 +222,35 @@ def test_full_etl_flow(db_connector: DatabaseConnectorInterface) -> None:
             }
         ]
     )
+    updated_eligibility_df = pd.DataFrame(
+        [
+            {
+                "nct_id": "NCT00000123",
+                "sex": "FEMALE",
+                "minimum_age": "21 Years",
+                "maximum_age": "65 Years",
+                "criteria": "Updated criteria",
+            }
+        ]
+    )
+    updated_locations_df = pd.DataFrame(
+        [
+            {
+                "nct_id": "NCT00000123",
+                "city": "New York",
+                "state": "New York",
+                "zip": "10002",  # Changed zip
+                "country": "United States",
+            },
+            {
+                "nct_id": "NCT00000123",
+                "city": "Chicago",  # New city
+                "state": "Illinois",
+                "zip": "60601",
+                "country": "United States",
+            },
+        ]
+    )
 
     # Load updated data
     db_connector.bulk_load_staging("studies", updated_studies_df)
@@ -179,21 +259,55 @@ def test_full_etl_flow(db_connector: DatabaseConnectorInterface) -> None:
     db_connector.execute_merge(
         "interventions", primary_keys=["nct_id", "intervention_type", "name"]
     )
+    db_connector.bulk_load_staging("eligibility_criteria", updated_eligibility_df)
+    db_connector.execute_merge("eligibility_criteria", primary_keys=["nct_id"])
+    db_connector.bulk_load_staging("locations", updated_locations_df)
+    db_connector.execute_merge(
+        "locations", primary_keys=["nct_id", "city", "state", "country"]
+    )
 
     # Verify the update
     with pg_connector.conn.cursor() as cur:
         # Check that the study was updated (UPSERT)
         cur.execute("SELECT brief_title FROM studies WHERE nct_id = 'NCT00000123'")
-        assert cur.fetchone()[0] == "Updated Title"
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == "Updated Title"
         cur.execute("SELECT COUNT(*) FROM studies WHERE nct_id = 'NCT00000123'")
-        assert cur.fetchone()[0] == 1
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
 
         # Check that interventions were replaced (DELETE then INSERT)
         cur.execute("SELECT COUNT(*) FROM interventions WHERE nct_id = 'NCT00000123'")
-        assert cur.fetchone()[0] == 1
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
         cur.execute("SELECT name FROM interventions WHERE nct_id = 'NCT00000123'")
-        assert cur.fetchone()[0] == "Stent"
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == "Stent"
         cur.execute(
             "SELECT name FROM interventions WHERE nct_id = 'NCT00000123' AND name = 'Aspirin'"
         )
         assert cur.fetchone() is None  # The old intervention should be gone
+
+        # Check that eligibility was updated (UPSERT)
+        cur.execute("SELECT sex FROM eligibility_criteria WHERE nct_id = 'NCT00000123'")
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == "FEMALE"
+
+        # Check that locations were replaced (DELETE then INSERT)
+        cur.execute("SELECT COUNT(*) FROM locations WHERE nct_id = 'NCT00000123'")
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 2
+        cur.execute(
+            "SELECT city FROM locations WHERE nct_id = 'NCT00000123' AND city = 'Chicago'"
+        )
+        assert cur.fetchone() is not None
+        cur.execute(
+            "SELECT city FROM locations WHERE nct_id = 'NCT00000123' AND city = 'Boston'"
+        )
+        assert cur.fetchone() is None  # The old location should be gone

--- a/tests/integration/test_orchestrator_flow.py
+++ b/tests/integration/test_orchestrator_flow.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 from unittest.mock import MagicMock, create_autospec
 
 from py_load_clinicaltrialsgov.connectors.postgres import PostgresConnector
@@ -8,7 +7,6 @@ from py_load_clinicaltrialsgov.transformer.transformer import Transformer
 from py_load_clinicaltrialsgov.orchestrator import Orchestrator
 
 # Import fixtures from the other test file
-from .test_full_etl import postgres_container, db_connector
 
 
 # A valid study record that should process successfully
@@ -95,22 +93,34 @@ def test_orchestrator_full_run(
     with db_connector.conn.cursor() as cur:
         # 1. Check for the successfully processed study
         cur.execute("SELECT COUNT(*) FROM studies")
-        assert cur.fetchone()[0] == 1
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
         cur.execute("SELECT brief_title FROM studies WHERE nct_id = 'NCT000001'")
-        assert cur.fetchone()[0] == "Valid Study"
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == "Valid Study"
         cur.execute("SELECT COUNT(*) FROM conditions WHERE nct_id = 'NCT000001'")
-        assert cur.fetchone()[0] == 1
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
 
         # 2. Check that the raw payload for the SUCCESSFUL study was stored
         cur.execute("SELECT COUNT(*) FROM raw_studies")
-        assert cur.fetchone()[0] == 1
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 1
         cur.execute("SELECT payload FROM raw_studies WHERE nct_id = 'NCT000001'")
-        raw_payload = cur.fetchone()[0]
+        result = cur.fetchone()
+        assert result is not None
+        raw_payload = result[0]
         assert raw_payload["protocolSection"]["identificationModule"]["nctId"] == "NCT000001"
 
         # 3. Check for the quarantined records in the dead-letter queue
         cur.execute("SELECT COUNT(*) FROM dead_letter_queue")
-        assert cur.fetchone()[0] == 2
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0] == 2
 
         # 4. Check the record that failed due to missing NCT ID
         cur.execute("SELECT nct_id, error_message FROM dead_letter_queue WHERE nct_id IS NULL")
@@ -130,7 +140,8 @@ def test_orchestrator_full_run(
         history = cur.fetchone()
         assert history is not None
         # Should be 1 record processed successfully, not 3
-        assert history[1]["records_processed"] == 1
-        assert history[1]["records_loaded_per_table"]["studies"] == 1
-        assert history[1]["records_loaded_per_table"]["raw_studies"] == 1
-        assert history[1]["records_loaded_per_table"]["conditions"] == 1
+        metrics = history[1]
+        assert metrics["records_processed"] == 1
+        assert metrics["records_loaded_per_table"]["studies"] == 1
+        assert metrics["records_loaded_per_table"]["raw_studies"] == 1
+        assert metrics["records_loaded_per_table"]["conditions"] == 1

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -2,9 +2,7 @@ import httpx
 import pytest
 from datetime import datetime
 from typing import List, Tuple, Any
-from unittest.mock import MagicMock
 
-from tenacity import RetryError
 
 from py_load_clinicaltrialsgov.extractor.api_client import APIClient
 from py_load_clinicaltrialsgov.config import settings

--- a/tests/unit/test_api_models.py
+++ b/tests/unit/test_api_models.py
@@ -1,3 +1,4 @@
+from typing import Any
 import pytest
 from pydantic import ValidationError
 
@@ -8,46 +9,46 @@ from py_load_clinicaltrialsgov.models.api_models import (
 )
 
 
-def test_description_module_valid():
+def test_description_module_valid() -> None:
     """Tests that a valid DescriptionModule is parsed correctly."""
-    data = {"briefSummary": "This is a test summary."}
+    data: dict[str, Any] = {"briefSummary": "This is a test summary."}
     module = DescriptionModule.model_validate(data)
     assert module.brief_summary == "This is a test summary."
 
 
-def test_description_module_empty():
+def test_description_module_empty() -> None:
     """Tests that an empty DescriptionModule is parsed correctly."""
-    data = {}
+    data: dict[str, Any] = {}
     module = DescriptionModule.model_validate(data)
     assert module.brief_summary is None
 
 
-def test_conditions_module_valid():
+def test_conditions_module_valid() -> None:
     """Tests that a valid ConditionsModule is parsed correctly."""
-    data = {"conditions": ["Cancer", "Diabetes"]}
+    data: dict[str, Any] = {"conditions": ["Cancer", "Diabetes"]}
     module = ConditionsModule.model_validate(data)
     assert module.conditions == ["Cancer", "Diabetes"]
 
 
-def test_conditions_module_empty_list():
+def test_conditions_module_empty_list() -> None:
     """Tests that a ConditionsModule with an empty list is parsed correctly."""
-    data = {"conditions": []}
+    data: dict[str, Any] = {"conditions": []}
     module = ConditionsModule.model_validate(data)
     assert module.conditions == []
 
 
-def test_conditions_module_null_conditions():
+def test_conditions_module_null_conditions() -> None:
     """Tests that a ConditionsModule with null conditions is parsed correctly."""
-    data = {"conditions": None}
+    data: dict[str, Any] = {"conditions": None}
     module = ConditionsModule.model_validate(data)
     assert module.conditions is None
 
 
-def test_protocol_section_with_new_models():
+def test_protocol_section_with_new_models() -> None:
     """
     Tests that the ProtocolSection correctly uses the new, typed models.
     """
-    data = {
+    data: dict[str, Any] = {
         "identificationModule": {"nctId": "NCT123"},
         "statusModule": {"overallStatus": "COMPLETED"},
         "descriptionModule": {"briefSummary": "A valid summary."},
@@ -60,7 +61,7 @@ def test_protocol_section_with_new_models():
     assert protocol.conditions_module.conditions == ["Condition 1"]
 
 
-def test_protocol_section_validation_error():
+def test_protocol_section_validation_error() -> None:
     """
     Tests that a validation error is raised for invalid data in the new models.
     """

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,9 @@
+from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from py_load_clinicaltrialsgov.cli import app
-from py_load_clinicaltrialsgov.models.api_models import Study
 
 # Create a runner for testing the Typer app
 runner = CliRunner()
@@ -39,7 +39,7 @@ def test_run_command_sends_invalid_study_to_dlq(
     """
     # Arrange
     # This payload is invalid because it's missing the 'identificationModule'
-    invalid_study_payload = {"protocolSection": {"statusModule": {}}}
+    invalid_study_payload: dict[str, Any] = {"protocolSection": {"statusModule": {}}}
 
     # Configure mocks
     mock_api_client.get_all_studies.return_value = iter([invalid_study_payload])
@@ -125,7 +125,7 @@ def test_status_command_failed_with_previous_success(mock_connector: MagicMock) 
         "status": "FAILURE",
         "metrics": {"error": "connection timed out"},
     }
-    successful_record = {
+    successful_record: dict[str, Any] = {
         "load_timestamp": datetime(2023, 1, 1, 12, 0, 0),
         "status": "SUCCESS",
         "metrics": {"records_processed": 100},

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,13 +1,12 @@
 import unittest
-from unittest.mock import MagicMock, patch, call
-from pydantic import ValidationError
+from unittest.mock import MagicMock, call
 
 from py_load_clinicaltrialsgov.orchestrator import Orchestrator
 from py_load_clinicaltrialsgov.models.api_models import Study
 
 
 class TestOrchestrator(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.mock_connector = MagicMock()
         self.mock_api_client = MagicMock()
         self.mock_transformer = MagicMock()
@@ -39,7 +38,7 @@ class TestOrchestrator(unittest.TestCase):
             "hasResults": False,
         }
 
-    def test_orchestrator_handles_validation_error_gracefully(self):
+    def test_orchestrator_handles_validation_error_gracefully(self) -> None:
         """
         Verify that the orchestrator can handle a Pydantic validation error.
 

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -4,7 +4,7 @@ from py_load_clinicaltrialsgov.transformer.transformer import Transformer
 from py_load_clinicaltrialsgov.models.api_models import Study
 
 
-def test_transform_study():
+def test_transform_study() -> None:
     # Create a mock study object
     mock_study_data = {
         "protocolSection": {
@@ -75,12 +75,12 @@ def test_transform_study():
         ("", None),
     ],
 )
-def test_normalize_date(date_str, expected_date):
+def test_normalize_date(date_str: str | None, expected_date: datetime | None) -> None:
     transformer = Transformer()
     assert transformer._normalize_date(date_str) == expected_date
 
 
-def test_transform_study_with_collaborators():
+def test_transform_study_with_collaborators() -> None:
     mock_study_data = {
         "protocolSection": {
             "identificationModule": {"nctId": "NCT54321"},
@@ -107,11 +107,11 @@ def test_transform_study_with_collaborators():
     sponsors_df = dataframes["sponsors"]
     assert len(sponsors_df) == 3
 
-    lead_sponsor = sponsors_df[sponsors_df["is_lead"] == True]
+    lead_sponsor = sponsors_df[sponsors_df["is_lead"]]
     assert len(lead_sponsor) == 1
     assert lead_sponsor.iloc[0]["name"] == "Lead Sponsor Inc."
 
-    collaborators = sponsors_df[sponsors_df["is_lead"] == False]
+    collaborators = sponsors_df[~sponsors_df["is_lead"]]
     assert len(collaborators) == 2
     assert "Collaborator 1" in collaborators["name"].values
     assert "Collaborator 2" in collaborators["name"].values

--- a/tests/unit/test_transformer_new.py
+++ b/tests/unit/test_transformer_new.py
@@ -1,7 +1,5 @@
-import json
 import pytest
 import pandas as pd
-from pathlib import Path
 from py_load_clinicaltrialsgov.models.api_models import Study
 from py_load_clinicaltrialsgov.transformer.transformer import Transformer
 
@@ -80,7 +78,7 @@ def transformer() -> Transformer:
 
 def test_transform_single_study_smoke(
     transformer: Transformer, sample_study: Study
-):
+) -> None:
     """Smoke test to ensure transform_study runs without errors."""
     try:
         transformer.transform_study(sample_study, SAMPLE_STUDY_PAYLOAD)
@@ -88,7 +86,7 @@ def test_transform_single_study_smoke(
         pytest.fail(f"transform_study raised an exception: {e}")
 
 
-def test_get_dataframes(transformer: Transformer, sample_study: Study):
+def test_get_dataframes(transformer: Transformer, sample_study: Study) -> None:
     """Test that get_dataframes returns the correct structure."""
     transformer.transform_study(sample_study, SAMPLE_STUDY_PAYLOAD)
     dfs = transformer.get_dataframes()
@@ -105,7 +103,7 @@ def test_get_dataframes(transformer: Transformer, sample_study: Study):
     assert all(not df.empty for df in dfs.values())
 
 
-def test_studies_table_content(transformer: Transformer, sample_study: Study):
+def test_studies_table_content(transformer: Transformer, sample_study: Study) -> None:
     """Verify the content of the 'studies' dataframe."""
     transformer.transform_study(sample_study, SAMPLE_STUDY_PAYLOAD)
     df = transformer.get_dataframes()["studies"]
@@ -121,23 +119,23 @@ def test_studies_table_content(transformer: Transformer, sample_study: Study):
     assert study_row["start_date_str"] == "1995-01-01"
 
 
-def test_sponsors_table_content(transformer: Transformer, sample_study: Study):
+def test_sponsors_table_content(transformer: Transformer, sample_study: Study) -> None:
     """Verify the content of the 'sponsors' dataframe, including collaborators."""
     transformer.transform_study(sample_study, SAMPLE_STUDY_PAYLOAD)
     df = transformer.get_dataframes()["sponsors"]
 
     assert df.shape[0] == 3  # 1 lead sponsor + 2 collaborators
 
-    lead_sponsor = df[df["is_lead"] == True]
+    lead_sponsor = df[df["is_lead"]]
     assert lead_sponsor.shape[0] == 1
     assert lead_sponsor.iloc[0]["name"] == "National Cancer Institute"
     assert lead_sponsor.iloc[0]["agency_class"] == "NIH"
 
-    collaborators = df[df["is_lead"] == False]
+    collaborators = df[~df["is_lead"]]
     assert collaborators.shape[0] == 2
 
 
-def test_child_tables_row_counts(transformer: Transformer, sample_study: Study):
+def test_child_tables_row_counts(transformer: Transformer, sample_study: Study) -> None:
     """Verify row counts for all child tables."""
     transformer.transform_study(sample_study, SAMPLE_STUDY_PAYLOAD)
     dfs = transformer.get_dataframes()
@@ -147,7 +145,7 @@ def test_child_tables_row_counts(transformer: Transformer, sample_study: Study):
     assert dfs["design_outcomes"].shape[0] == 2  # 1 primary + 1 secondary
 
 
-def test_design_outcomes_content(transformer: Transformer, sample_study: Study):
+def test_design_outcomes_content(transformer: Transformer, sample_study: Study) -> None:
     """Verify the content of the 'design_outcomes' table."""
     transformer.transform_study(sample_study, SAMPLE_STUDY_PAYLOAD)
     df = transformer.get_dataframes()["design_outcomes"]
@@ -161,16 +159,22 @@ def test_design_outcomes_content(transformer: Transformer, sample_study: Study):
     assert secondary.iloc[0]["measure"] == "Tumor Response"
 
 
-def test_date_normalization():
+def test_date_normalization() -> None:
     """Test the _normalize_date helper directly."""
     t = Transformer()
-    assert t._normalize_date("2023-10-25").year == 2023
-    assert t._normalize_date("October 2023").month == 10
-    assert t._normalize_date("2023").day == 1
+    date1 = t._normalize_date("2023-10-25")
+    assert date1 is not None
+    assert date1.year == 2023
+    date2 = t._normalize_date("October 2023")
+    assert date2 is not None
+    assert date2.month == 10
+    date3 = t._normalize_date("2023")
+    assert date3 is not None
+    assert date3.day == 1
     assert t._normalize_date(None) is None
     assert t._normalize_date("Invalid Date") is None
 
-def test_clear_function(transformer: Transformer, sample_study: Study):
+def test_clear_function(transformer: Transformer, sample_study: Study) -> None:
     """Test that the clear function resets the internal state."""
     transformer.transform_study(sample_study, SAMPLE_STUDY_PAYLOAD)
     assert not transformer.get_dataframes()["studies"].empty


### PR DESCRIPTION
This commit adds the functionality to extract, transform, and load location and eligibility data from the ClinicalTrials.gov V2 API.

This addresses a major gap in the ETL process, making the resulting dataset more complete and useful for analysis.

Key changes:
- Extended the Pydantic models in `api_models.py` to include `EligibilityModule` and `ContactsLocationsModule`.
- Added `locations` and `eligibility_criteria` tables to the database schema in `sql/schema.sql`.
- Created a new Alembic migration to apply the schema changes.
- Enhanced the `Transformer` to parse the new data modules and create corresponding dataframes.
- Updated the `Orchestrator` to handle the loading and merging of the new tables.
- Extended the integration tests in `tests/integration/test_full_etl.py` to verify the new functionality.
- Fixed numerous mypy and ruff linting issues across the codebase to improve code quality and maintainability.

The test suite passes, including the new integration tests for the added functionality. There are a few remaining mypy errors that need to be addressed in a future commit.